### PR TITLE
fix-multi-account-secret-key-error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,8 +9,13 @@ import { createWebhook, retrieveWebhook, listWebhooks, toggleWebhook } from './w
 
 export default class Paymongo {
   constructor (secret) {
-    if (Paymongo.instance instanceof Paymongo) return Paymongo.instance;
     if (!secret) throw new Error('API key is required!');
+
+    if (Paymongo.instance instanceof Paymongo) {
+      if (Paymongo.instance.secret === secret) {
+        return Paymongo.instance;
+      }
+    }
     this.secret = secret;
 
     // PAYMENT METHODS


### PR DESCRIPTION
Describe the bug
We are using this library to process payment with different paymongo account in the same application runtime. Cause of the Singleton design pattern we sometime don't have the ref to the expected Paymongo instance.

To Reproduce
paymongo1 = new Paymongo("secretKey1");
...
paymongo2 = new Paymongo("another_secretKey");
...

Expected behavior
The constructor should double check the existing instance API Key to avoid this